### PR TITLE
Fixed parametrization and conditionals

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ Usage
 -----
 
 This role works by setting up pxe booting based on groups. It configures PXE
-booting for all hosts in the "pxe_bootable_nodes" group. Each host needs the
-follwing variables in its scope.
+booting for all hosts in the desired group. By default it's "dhcp_pxe_nodes",
+but it can be defined (check defaults/main.yml)
+
+Each host needs the follwing variables in its scope.
 
 Mandatory:
  - mac_address
@@ -39,11 +41,13 @@ Optional:
  - extra_kernel_params (for the kickstart)
 
 The nodes which only need to be set up for DHCP need to be in the
-"dhcp_only_nodes" group. These nodes need the following variables.
+(by default) "dhcp_only_nodes"  group. These nodes need the following 
+variables.
+
  - mac_address
  - ip_address
 
-It also configures a per-group kickstart file for each group which has the
+The role also configures a per-group kickstart file for each group which has the
 "os_disks" variable in its scope. For this it uses the following variables from
 the groups context.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+dhcp_group: "dhcp_only_hosts"
+dhcp_pxe_group: "dhcp_pxe_hosts"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,13 +23,15 @@
 - name: create_dhcpd_config_dir
   file: path=/etc/dhcp/dhcpd.d state=directory owner=root group=root mode="0755"
 
-- name: create_dhcp_configs
+- name: create_dhcp_config
   template: src=dhcp_nodes.conf dest="/etc/dhcp/dhcpd.d/dhcp_nodes.conf"
+  when: groups[dhcp_group] is defined
   notify:
     - restart dhcpd
 
-- name: create_dhcp_configs
+- name: create_dhcp_ipxe_configs
   template: src=dhcp_pxe_nodes.conf dest="/etc/dhcp/dhcpd.d/dhcp_pxe_nodes.conf"
+  when: groups[dhcp_pxe_group] is defined
   notify:
     - restart dhcpd
 
@@ -41,7 +43,9 @@
 
 - name: create_pxe_boot_data
   template: src=pxe_node.conf dest="/var/www/provision/nodes/{{ item | regex_replace('^([^\.]*).*$', '\\1')  }}.conf"
-  with_items: groups['pxe_bootable_nodes']
+  with_items: groups[dhcp_pxe_group]
+  when: groups[dhcp_pxe_group] is defined
+
 
 - name: copy_dhcp_pxe_option_config
   copy: src=ipxe.conf dest=/etc/dhcp/dhcpd.d/ipxe.conf owner=root group=root mode="0644"

--- a/templates/dhcp_nodes.conf
+++ b/templates/dhcp_nodes.conf
@@ -1,5 +1,5 @@
 # Hosts
-{% for item in groups['dhcp_only_nodes'] %}
+{% for item in groups[dhcp_group] %}
 host {{ item }} {
   hardware ethernet {{ hostvars[item]['mac_address'] }};
   fixed-address {{  hostvars[item]['ip_address'] }};

--- a/templates/dhcp_pxe_nodes.conf
+++ b/templates/dhcp_pxe_nodes.conf
@@ -1,5 +1,5 @@
 # Hosts
-{% for item in groups['pxe_bootable_nodes'] %}
+{% for item in groups[dhcp_pxe_group] %}
 host {{ item }} {
   hardware ethernet {{ hostvars[item]['mac_address'] }};
   fixed-address {{  hostvars[item]['ip_address'] }};


### PR DESCRIPTION
The groups you want to add to dhcp/pxe booting are now definable. These
are also called conditionally, so nothing will be done if the groups are
missing.