### PR TITLE
Configurable domain for dhcp hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ Each host needs the follwing variables in its scope.
 Mandatory:
  - mac_address
  - ip_address
- - dhcp_common_domain  (the domain component of the hostname)
  - dhcp_server_ip
  - kickstart_url
  - kernel_url_path (path where kickstart kernel and initrd can be found)
 
 Optional:
  - extra_kernel_params (for the kickstart)
+ - dhcp_domain
 
 The nodes which only need to be set up for DHCP need to be in the
 (by default) "dhcp_only_nodes"  group. These nodes need the following 

--- a/templates/dhcp_pxe_nodes.conf
+++ b/templates/dhcp_pxe_nodes.conf
@@ -3,7 +3,7 @@
 host {{ item }} {
   hardware ethernet {{ hostvars[item]['mac_address'] }};
   fixed-address {{  hostvars[item]['ip_address'] }};
-  send host-name "{{ item | regex_replace('^([^\.]*).*$', '\\1') }}.{{ dhcp_common_domain }}";
+  send host-name "{{ item | regex_replace('^([^\.]*).*$', '\\1') }}.{{  hostvars[item]['dhcp_domain'] | default( dhcp_common_domain ) }}";
 
   if exists ipxe.http or exists ipxe.efi {
       filename "http://{{ hostvars[item]['dhcp_server_ip'] }}/cgi-bin/boot.py";


### PR DESCRIPTION
By default all hosts were in the same domain. This patch allows you to
overwrite the domain name on a per-host basis.